### PR TITLE
[codex] Add mega Typst build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ debug_gh_verify.scad
 .python-version
 .ruff_cache/
 .venv/
+__pycache__/
+*.py[cod]
 
 # Generated Assets
 vehicles/*/gen/*

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ PDFS_A4 := $(addprefix $(BUILD_DIR)/,$(addsuffix _a4.pdf,$(UNIVERSAL_VARIANT_STE
 PNGS_A4 := $(addprefix $(BUILD_DIR)/,$(addsuffix _a4.png,$(UNIVERSAL_VARIANT_STEMS)))
 PNGS_BW := $(addprefix $(BUILD_DIR)/,$(addsuffix _letter_bw.png,$(UNIVERSAL_VARIANT_STEMS)))
 PNGS_A4_BW := $(addprefix $(BUILD_DIR)/,$(addsuffix _a4_bw.png,$(UNIVERSAL_VARIANT_STEMS)))
+UNIVERSAL_SVGS := $(addprefix $(BUILD_DIR)/,$(addsuffix _mount.svg,$(UNIVERSAL_MOUNTS)))
+MEGA_DIR := $(BUILD_DIR)/mega
+MEGA_UNIVERSAL_LETTER_STAMP := $(MEGA_DIR)/universal_letter.stamp
+MEGA_UNIVERSAL_A4_STAMP := $(MEGA_DIR)/universal_a4.stamp
+MEGA_VEHICLE_LETTER_STAMP := $(MEGA_DIR)/vehicle_letter.stamp
+MEGA_VEHICLE_A4_STAMP := $(MEGA_DIR)/vehicle_a4.stamp
 CUTTING_TEMPLATES := $(BUILD_DIR)/c3_cutting_template.stl $(BUILD_DIR)/c3x_cutting_template.stl $(BUILD_DIR)/c4_cutting_template.stl \
                      $(BUILD_DIR)/c3x_cutting_template_solid.stl $(BUILD_DIR)/c4_cutting_template_solid.stl
 CUTTING_PREVIEWS := $(BUILD_DIR)/c3_cutting_template_preview.png $(BUILD_DIR)/c3x_cutting_template_preview.png $(BUILD_DIR)/c4_cutting_template_preview.png
@@ -41,13 +47,27 @@ CUTTING_PREVIEWS := $(BUILD_DIR)/c3_cutting_template_preview.png $(BUILD_DIR)/c3
 # Keep intermediate SVGs, TYP files, and oriented STLs
 .SECONDARY: $(PDFS:.pdf=.typ) $(PDFS_A4:.pdf=.typ)
 
-.PHONY: all clean update-hardware debug universal-variants
+.PHONY: all clean update-hardware debug universal-variants universal-render vehicles-render render-templates bench-build
 
+ifeq ($(INDIVIDUAL),1)
 all: $(PDFS) $(PNGS) $(PDFS_A4) $(PNGS_A4) $(PNGS_BW) $(PNGS_A4_BW) vehicles cutting-templates cutting-previews
 	@echo "All templates built successfully."
 
 universal-variants: $(PDFS) $(PDFS_A4)
 	@echo "Universal variant PDFs built successfully."
+
+universal-render: $(PDFS) $(PNGS) $(PDFS_A4) $(PNGS_A4)
+	@echo "Universal variant PDFs and PNGs built with individual Typst compiles."
+else
+all: universal-render $(PNGS_BW) $(PNGS_A4_BW) vehicles cutting-templates cutting-previews
+	@echo "All templates built successfully."
+
+universal-variants: universal-render
+	@echo "Universal variant PDFs and PNGs built successfully."
+
+universal-render: $(MEGA_UNIVERSAL_LETTER_STAMP) $(MEGA_UNIVERSAL_A4_STAMP)
+	@echo "Universal variant PDFs and PNGs built with mega Typst compiles."
+endif
 
 cutting-templates: $(CUTTING_TEMPLATES)
 	@echo "All cutting templates built successfully."
@@ -62,6 +82,9 @@ verify: all
 debug:
 	@echo "PDFS (Letter Landscape): $(PDFS)"
 	@echo "PDFS (A4 Landscape): $(PDFS_A4)"
+
+bench-build:
+	uv run tools/benchmark_build.py
 
 update-hardware:
 	git submodule update --init --recursive
@@ -225,6 +248,27 @@ $(BUILD_DIR)/%_bw.png: $(BUILD_DIR)/%.png
 	@echo "Converting $< to greyscale..."
 	uv run tools/grayscale.py $< $@
 
+$(MEGA_DIR):
+	$(MKDIR) $(MEGA_DIR)
+
+MEGA_UNIVERSAL_DEPS := $(UNIVERSAL_SVGS) template.typ tools/build_mega_templates.py fonts/DejaVuSansMono.ttf img/car_with_centerline.svg
+
+$(MEGA_UNIVERSAL_LETTER_STAMP): $(MEGA_UNIVERSAL_DEPS) | $(MEGA_DIR)
+	@echo "Building universal Letter mega Typst group..."
+	uv run tools/build_mega_templates.py --group universal-letter --typst "$(TYPST)" --stamp "$@"
+
+$(MEGA_UNIVERSAL_A4_STAMP): $(MEGA_UNIVERSAL_DEPS) | $(MEGA_DIR)
+	@echo "Building universal A4 mega Typst group..."
+	uv run tools/build_mega_templates.py --group universal-a4 --typst "$(TYPST)" --stamp "$@"
+
+ifneq ($(INDIVIDUAL),1)
+$(PDFS) $(PNGS): $(MEGA_UNIVERSAL_LETTER_STAMP)
+	@test -f "$@" || { rm -f "$(MEGA_UNIVERSAL_LETTER_STAMP)"; $(MAKE) "$(MEGA_UNIVERSAL_LETTER_STAMP)"; test -f "$@"; }
+
+$(PDFS_A4) $(PNGS_A4): $(MEGA_UNIVERSAL_A4_STAMP)
+	@test -f "$@" || { rm -f "$(MEGA_UNIVERSAL_A4_STAMP)"; $(MAKE) "$(MEGA_UNIVERSAL_A4_STAMP)"; test -f "$@"; }
+endif
+
 
 
 VEHICLES_DIR := vehicles
@@ -233,6 +277,8 @@ VEHICLE_VARIANT_OFFSETS_MM := 45 50 55 60 65
 
 # Target lists
 VEHICLE_PDFS :=
+VEHICLE_COLOR_PNGS :=
+VEHICLE_BW_PNGS :=
 VEHICLE_PNGS :=
 
 # Helper to generate targets for a vehicle
@@ -242,13 +288,13 @@ VEHICLE_PDFS += $(BUILD_DIR)/vehicles/$(1)/c3_mount_letter.pdf $(BUILD_DIR)/vehi
 VEHICLE_PDFS += $(BUILD_DIR)/vehicles/$(1)/c3x_mount_letter.pdf $(BUILD_DIR)/vehicles/$(1)/c3x_mount_a4.pdf
 VEHICLE_PDFS += $(BUILD_DIR)/vehicles/$(1)/c4_mount_letter.pdf $(BUILD_DIR)/vehicles/$(1)/c4_mount_a4.pdf
 
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/$(1)/c3_mount_letter.png $(BUILD_DIR)/vehicles/$(1)/c3_mount_a4.png
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/$(1)/c3x_mount_letter.png $(BUILD_DIR)/vehicles/$(1)/c3x_mount_a4.png
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/$(1)/c4_mount_letter.png $(BUILD_DIR)/vehicles/$(1)/c4_mount_a4.png
+VEHICLE_COLOR_PNGS += $(BUILD_DIR)/vehicles/$(1)/c3_mount_letter.png $(BUILD_DIR)/vehicles/$(1)/c3_mount_a4.png
+VEHICLE_COLOR_PNGS += $(BUILD_DIR)/vehicles/$(1)/c3x_mount_letter.png $(BUILD_DIR)/vehicles/$(1)/c3x_mount_a4.png
+VEHICLE_COLOR_PNGS += $(BUILD_DIR)/vehicles/$(1)/c4_mount_letter.png $(BUILD_DIR)/vehicles/$(1)/c4_mount_a4.png
 
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/$(1)/c3_mount_letter_bw.png $(BUILD_DIR)/vehicles/$(1)/c3_mount_a4_bw.png
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/$(1)/c3x_mount_letter_bw.png $(BUILD_DIR)/vehicles/$(1)/c3x_mount_a4_bw.png
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/$(1)/c4_mount_letter_bw.png $(BUILD_DIR)/vehicles/$(1)/c4_mount_a4_bw.png
+VEHICLE_BW_PNGS += $(BUILD_DIR)/vehicles/$(1)/c3_mount_letter_bw.png $(BUILD_DIR)/vehicles/$(1)/c3_mount_a4_bw.png
+VEHICLE_BW_PNGS += $(BUILD_DIR)/vehicles/$(1)/c3x_mount_letter_bw.png $(BUILD_DIR)/vehicles/$(1)/c3x_mount_a4_bw.png
+VEHICLE_BW_PNGS += $(BUILD_DIR)/vehicles/$(1)/c4_mount_letter_bw.png $(BUILD_DIR)/vehicles/$(1)/c4_mount_a4_bw.png
 
 # Explicit Compilation Rules for this vehicle
 $(BUILD_DIR)/vehicles/$(1)/c3_mount_letter.pdf $(BUILD_DIR)/vehicles/$(1)/c3_mount_a4.pdf: $(BUILD_DIR)/c3_mount.svg
@@ -275,14 +321,14 @@ $(foreach v,$(VEHICLES),$(eval $(call generate_vehicle_targets,$v)))
 # Vehicle variant matrices (5 offsets x 3 mounts x 2 paper sizes)
 define generate_corolla_variant_targets
 VEHICLE_PDFS += $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_letter.pdf $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_a4.pdf
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_letter.png $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_a4.png
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_letter_bw.png $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_a4_bw.png
+VEHICLE_COLOR_PNGS += $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_letter.png $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_a4.png
+VEHICLE_BW_PNGS += $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_letter_bw.png $(BUILD_DIR)/vehicles/2020_corolla/$(1)_mount_$(2)mm_a4_bw.png
 endef
 
 define generate_santa_fe_variant_targets
 VEHICLE_PDFS += $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_letter.pdf $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_a4.pdf
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_letter.png $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_a4.png
-VEHICLE_PNGS += $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_letter_bw.png $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_a4_bw.png
+VEHICLE_COLOR_PNGS += $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_letter.png $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_a4.png
+VEHICLE_BW_PNGS += $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_letter_bw.png $(BUILD_DIR)/vehicles/2020_hyundai_santa_fe/$(1)_mount_$(2)mm_a4_bw.png
 endef
 
 $(foreach offset,$(VEHICLE_VARIANT_OFFSETS_MM),$(eval $(call generate_corolla_variant_targets,c3,$(offset))))
@@ -292,7 +338,47 @@ $(foreach offset,$(VEHICLE_VARIANT_OFFSETS_MM),$(eval $(call generate_santa_fe_v
 $(foreach offset,$(VEHICLE_VARIANT_OFFSETS_MM),$(eval $(call generate_santa_fe_variant_targets,c3x,$(offset))))
 $(foreach offset,$(VEHICLE_VARIANT_OFFSETS_MM),$(eval $(call generate_santa_fe_variant_targets,c4,$(offset))))
 
+VEHICLE_PNGS := $(VEHICLE_COLOR_PNGS) $(VEHICLE_BW_PNGS)
+VEHICLE_LETTER_RENDER_OUTPUTS := $(filter %_letter.pdf,$(VEHICLE_PDFS)) $(filter %_letter.png,$(VEHICLE_COLOR_PNGS))
+VEHICLE_A4_RENDER_OUTPUTS := $(filter %_a4.pdf,$(VEHICLE_PDFS)) $(filter %_a4.png,$(VEHICLE_COLOR_PNGS))
+VEHICLE_RENDER_DEPS := $(BUILD_DIR)/c3_mount.svg $(BUILD_DIR)/c3x_mount.svg $(BUILD_DIR)/c4_mount.svg template.typ tools/build_mega_templates.py fonts/DejaVuSansMono.ttf img/car_with_centerline.svg \
+                       $(foreach v,$(VEHICLES),$(VEHICLES_DIR)/$(v)/template.typ $(VEHICLES_DIR)/$(v)/name.txt $(VEHICLES_DIR)/$(v)/gen/offsets.svg)
+
+ifeq ($(INDIVIDUAL),1)
 vehicles: $(VEHICLE_PDFS) $(VEHICLE_PNGS)
+	@echo "Vehicle PDFs and PNGs built with individual Typst compiles."
+
+vehicles-render: $(VEHICLE_PDFS) $(VEHICLE_COLOR_PNGS)
+	@echo "Vehicle PDFs and color PNGs built with individual Typst compiles."
+
+render-templates: universal-render vehicles-render
+	@echo "All template PDFs and color PNGs built with individual Typst compiles."
+else
+vehicles: vehicles-render $(VEHICLE_BW_PNGS)
+	@echo "Vehicle PDFs and PNGs built with mega Typst compiles."
+
+vehicles-render: $(MEGA_VEHICLE_LETTER_STAMP) $(MEGA_VEHICLE_A4_STAMP)
+	@echo "Vehicle PDFs and color PNGs built with mega Typst compiles."
+
+render-templates: universal-render vehicles-render
+	@echo "All template PDFs and color PNGs built with mega Typst compiles."
+endif
+
+$(MEGA_VEHICLE_LETTER_STAMP): $(VEHICLE_RENDER_DEPS) | $(MEGA_DIR)
+	@echo "Building vehicle Letter mega Typst group..."
+	uv run tools/build_mega_templates.py --group vehicle-letter --typst "$(TYPST)" --stamp "$@"
+
+$(MEGA_VEHICLE_A4_STAMP): $(VEHICLE_RENDER_DEPS) | $(MEGA_DIR)
+	@echo "Building vehicle A4 mega Typst group..."
+	uv run tools/build_mega_templates.py --group vehicle-a4 --typst "$(TYPST)" --stamp "$@"
+
+ifneq ($(INDIVIDUAL),1)
+$(VEHICLE_LETTER_RENDER_OUTPUTS): $(MEGA_VEHICLE_LETTER_STAMP)
+	@test -f "$@" || { rm -f "$(MEGA_VEHICLE_LETTER_STAMP)"; $(MAKE) "$(MEGA_VEHICLE_LETTER_STAMP)"; test -f "$@"; }
+
+$(VEHICLE_A4_RENDER_OUTPUTS): $(MEGA_VEHICLE_A4_STAMP)
+	@test -f "$@" || { rm -f "$(MEGA_VEHICLE_A4_STAMP)"; $(MAKE) "$(MEGA_VEHICLE_A4_STAMP)"; test -f "$@"; }
+endif
 
 # Target-specific variables for mount types
 $(BUILD_DIR)/vehicles/%/c3_mount_letter.typ $(BUILD_DIR)/vehicles/%/c3_mount_a4.typ: MOUNT_NAME_PREFIX="comma three"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ In GitHub Actions, the Pages workflow uses `make -j "$(nproc)"` so build paralle
     -   A credit card outline for scale validation.
     -   Clearance zone markings.
     -   Title and instructional text.
+5.  **Mega Rendering**: By default, `make all`, `make universal-variants`, and `make vehicles` render grouped multi-page Typst documents under `build/mega/`, then split or rename the pages back to the same public PDF and PNG filenames. This avoids launching Typst once per variant while preserving the published artifact layout.
+6.  **Debug Rendering**: To render with the older one-file-per-template path, pass `INDIVIDUAL=1`, for example `make INDIVIDUAL=1 build/c4_mount_45_75mm_letter.pdf` or `make INDIVIDUAL=1 universal-render`.
+7.  **Benchmarking**: Run `make bench-build` to compare individual Typst rendering against the mega renderer for universal PDFs and PNGs. For a broader comparison, run `uv run tools/benchmark_build.py --scope all --jobs 16`.
 
 ### AI / Computer Vision Workflow
 
@@ -221,7 +224,7 @@ An experimental workflow exists to trace vehicle features (like camera covers) f
 3.  **Process**: `tools/vehicle_specific/process_annotation.py` extracts the scale (pixels/mm) and the raw trace from the annotated image to `vehicles/<vehicle_name>/gen/raw_trace.svg`.
 4.  **Refine**: `tools/vehicle_specific/refine_trace.py` rotates, centers, and symmetrizes the trace for engineering use, saving to `vehicles/<vehicle_name>/gen/trace.svg`.
 5.  **Offsets**: `tools/vehicle_specific/generate_offsets.py` adds clearance lines and the centerline, creating the final `vehicles/<vehicle_name>/gen/offsets.svg` used in the template.
-6.  **Verify**: `make verify` runs `tools/verify_build.py`, which uses `gemini-3-flash-preview` to visually inspect all generated PDFs/PNGs. It checks for the presence of red clearance lines, correct labels, and legible text, failing the build if any template is suspect.
+6.  **Verify**: `make verify` runs `tools/verify_build.py`, which uses `gemini-3-flash-preview` through Vertex AI to visually inspect all generated PDFs/PNGs. It checks for the presence of red clearance lines, correct labels, and legible text, failing the build if any template is suspect. Set `GOOGLE_GENAI_USE_VERTEXAI=True` and `GOOGLE_CLOUD_PROJECT` in `.env` or the environment before running verification.
 
 ### Specifications
 
@@ -237,7 +240,7 @@ To build the templates locally, you will need:
 
 *   [OpenSCAD](https://openscad.org/) (headless support required)
 *   [Typst](https://typst.app/)
-*   Python 3 with `numpy-stl`, though [`uv`](https://docs.astral.sh/uv/) is used to manage dependencies.
+*   Python dependencies managed by [`uv`](https://docs.astral.sh/uv/), including `pypdf` for splitting mega PDFs back into per-template files.
 *   Make
 
 Those tools can be found in package managers such as `brew` on macOS, `apt` on Debian/Ubuntu, `dnf` on Fedora, etc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
     "shapely>=2.1.2",
     "trimesh>=4.11.1",
     "opencv-python-headless>=4.11.0.86",
+    "pypdf>=6.11.0",
 ]

--- a/tools/benchmark_build.py
+++ b/tools/benchmark_build.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import build_mega_templates
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(cmd: list[str]) -> None:
+    print("+ " + " ".join(cmd), flush=True)
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+def timed(cmd: list[str]) -> float:
+    start = time.perf_counter()
+    run(cmd)
+    return time.perf_counter() - start
+
+
+def groups_for_scope(scope: str) -> list[str]:
+    groups = ["universal-letter", "universal-a4"]
+    if scope == "all":
+        groups.extend(["vehicle-letter", "vehicle-a4"])
+    return groups
+
+
+def make_target_for_scope(scope: str) -> str:
+    return "universal-render" if scope == "universal" else "render-templates"
+
+
+def expected_outputs(scope: str) -> list[Path]:
+    return build_mega_templates.expected_outputs(groups_for_scope(scope))
+
+
+def remove_render_outputs(scope: str) -> None:
+    for output in expected_outputs(scope):
+        output.unlink(missing_ok=True)
+    shutil.rmtree(ROOT / "build" / "mega", ignore_errors=True)
+
+    for typ in (ROOT / "build").glob("*_letter.typ"):
+        typ.unlink(missing_ok=True)
+    for typ in (ROOT / "build").glob("*_a4.typ"):
+        typ.unlink(missing_ok=True)
+    for typ in (ROOT / "build" / "vehicles").glob("*/*.typ"):
+        typ.unlink(missing_ok=True)
+
+
+def verify_outputs(scope: str) -> int:
+    outputs = expected_outputs(scope)
+    missing = [output for output in outputs if not output.exists()]
+    if missing:
+        sample = "\n".join(str(path.relative_to(ROOT)) for path in missing[:10])
+        raise RuntimeError(f"missing {len(missing)} expected outputs:\n{sample}")
+    return len(outputs)
+
+
+def prebuild_shared_prereqs(scope: str, jobs: int) -> None:
+    prereqs = [
+        "build/c3_mount.svg",
+        "build/c3x_mount.svg",
+        "build/c4_mount.svg",
+        "build/konik_batman_mount.svg",
+        "build/konik_quickmount_mount.svg",
+    ]
+    if scope == "all":
+        prereqs.extend(
+            [
+                "vehicles/2020_corolla/gen/offsets.svg",
+                "vehicles/2020_hyundai_santa_fe/gen/offsets.svg",
+            ]
+        )
+    run(["make", "-j", str(jobs), *prereqs])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare individual vs mega Typst builds.")
+    parser.add_argument("--scope", choices=("universal", "all"), default="universal")
+    parser.add_argument("--jobs", type=int, default=os.cpu_count() or 1)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    target = make_target_for_scope(args.scope)
+
+    prebuild_shared_prereqs(args.scope, args.jobs)
+
+    remove_render_outputs(args.scope)
+    old_seconds = timed(["make", "-j", str(args.jobs), "INDIVIDUAL=1", target])
+    old_count = verify_outputs(args.scope)
+
+    remove_render_outputs(args.scope)
+    new_seconds = timed(["make", "-j", str(args.jobs), target])
+    new_count = verify_outputs(args.scope)
+
+    if old_count != new_count:
+        raise RuntimeError(f"old output count {old_count} != new output count {new_count}")
+
+    speedup = old_seconds / new_seconds if new_seconds > 0 else float("inf")
+    print(f"scope={args.scope}")
+    print(f"jobs={args.jobs}")
+    print(f"old_individual_seconds={old_seconds:.3f}")
+    print(f"new_mega_seconds={new_seconds:.3f}")
+    print(f"speedup={speedup:.2f}x")
+    print(f"outputs_checked={new_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/build_mega_templates.py
+++ b/tools/build_mega_templates.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from pypdf import PdfReader, PdfWriter
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_DIR = ROOT / "build"
+MEGA_DIR = BUILD_DIR / "mega"
+UNIVERSAL_OFFSETS_MM = (
+    (45, 75),
+    (50, 80),
+    (55, 85),
+    (60, 90),
+    (65, 95),
+    (70, 100),
+    (75, 105),
+    (80, 110),
+    (85, 115),
+    (90, 120),
+    (95, 125),
+)
+UNIVERSAL_MOUNTS = (
+    ("c3", "comma three", False),
+    ("c3x", "comma 3x", False),
+    ("c4", "comma four", False),
+    ("konik_batman", "Konik Batman", True),
+    ("konik_quickmount", "Konik Quick Mount", True),
+)
+VEHICLE_MOUNTS = (
+    ("c3", "comma three", 35),
+    ("c3x", "comma 3x", 35),
+    ("c4", "comma four", 44),
+)
+VEHICLE_VARIANT_OFFSETS_MM = (45, 50, 55, 60, 65)
+VEHICLE_VARIANT_DIRS = ("2020_corolla", "2020_hyundai_santa_fe")
+
+
+@dataclass(frozen=True)
+class Render:
+    pdf: Path
+    png: Path
+    body: str
+
+
+def run_git(args: list[str], default: str = "") -> str:
+    try:
+        return subprocess.check_output(["git", *args], cwd=ROOT, text=True).strip()
+    except subprocess.CalledProcessError:
+        return default
+
+
+def git_url() -> str:
+    url = run_git(["config", "--get", "remote.origin.url"])
+    if url.startswith("git@github.com:"):
+        url = "https://github.com/" + url.removeprefix("git@github.com:")
+    if url.endswith(".git"):
+        url = url.removesuffix(".git")
+    return url
+
+
+def typst_str(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def template_call(args: dict[str, str]) -> str:
+    rendered = ", ".join(f"{key}: {value}" for key, value in args.items())
+    return f"#template({rendered})"
+
+
+def common_git_args() -> dict[str, str]:
+    return {
+        "repo-url": typst_str(git_url()),
+        "commit-hash": typst_str(run_git(["rev-parse", "--short", "HEAD"])),
+        "commit-date": typst_str(run_git(["log", "-1", "--format=%cd", "--date=short"])),
+        "revision": typst_str(run_git(["rev-list", "--count", "HEAD"])),
+    }
+
+
+def universal_renders(paper: str) -> list[Render]:
+    renders: list[Render] = []
+    suffix = "a4" if paper == "a4" else "letter"
+    git_args = common_git_args()
+
+    for mount, label, is_konik in UNIVERSAL_MOUNTS:
+        for primary, secondary in UNIVERSAL_OFFSETS_MM:
+            stem = f"{mount}_mount_{primary}_{secondary}mm"
+            args = {
+                "mount-name": typst_str(
+                    f"{label} (paired {primary}mm/{secondary}mm)"
+                ),
+                "footprint-label": typst_str(label),
+                "svg-file": typst_str(f"build/{mount}_mount.svg"),
+                "clearance-offset": f"{primary}mm",
+                "secondary-clearance-offset": f"{secondary}mm",
+                **git_args,
+                "min-radius": "500mm",
+                "top-padding": "2cm",
+            }
+            if paper == "a4":
+                args["paper-size"] = typst_str("a4")
+            if is_konik:
+                args["feedback-community-url"] = typst_str("https://discord.gg/HCb2DbEKJD")
+                args["feedback-community-label"] = typst_str("Konik Discord")
+                args["feedback-community-channel"] = typst_str("")
+            renders.append(
+                Render(
+                    pdf=BUILD_DIR / f"{stem}_{suffix}.pdf",
+                    png=BUILD_DIR / f"{stem}_{suffix}.png",
+                    body=template_call(args),
+                )
+            )
+    return renders
+
+
+def vehicle_dirs() -> list[str]:
+    vehicles_root = ROOT / "vehicles"
+    return sorted(path.name for path in vehicles_root.iterdir() if path.is_dir())
+
+
+def vehicle_name(vehicle: str) -> str:
+    return (ROOT / "vehicles" / vehicle / "name.txt").read_text().strip()
+
+
+def vehicle_renders(paper: str) -> list[Render]:
+    renders: list[Render] = []
+    suffix = "a4" if paper == "a4" else "letter"
+    git_args = common_git_args()
+
+    for vehicle in vehicle_dirs():
+        name = vehicle_name(vehicle)
+        for mount, label, offset in VEHICLE_MOUNTS:
+            stem = f"{mount}_mount"
+            args = {
+                "mount-name": typst_str(f"{label} ({name})"),
+                "footprint-label": typst_str(label),
+                "svg-file": typst_str(f"build/{mount}_mount.svg"),
+                "clearance-offset": f"{offset}mm",
+                "custom-clearance-svg": typst_str(f"/vehicles/{vehicle}/gen/offsets.svg"),
+                **git_args,
+                "min-radius": "500mm",
+                "top-padding": "2cm",
+            }
+            if paper == "a4":
+                args["paper-size"] = typst_str("a4")
+            renders.append(
+                Render(
+                    pdf=BUILD_DIR / "vehicles" / vehicle / f"{stem}_{suffix}.pdf",
+                    png=BUILD_DIR / "vehicles" / vehicle / f"{stem}_{suffix}.png",
+                    body=template_call(args),
+                )
+            )
+
+    for vehicle in VEHICLE_VARIANT_DIRS:
+        name = vehicle_name(vehicle)
+        for mount, label, _default_offset in VEHICLE_MOUNTS:
+            for offset in VEHICLE_VARIANT_OFFSETS_MM:
+                stem = f"{mount}_mount_{offset}mm"
+                args = {
+                    "mount-name": typst_str(f"{label} ({name})"),
+                    "footprint-label": typst_str(label),
+                    "svg-file": typst_str(f"build/{mount}_mount.svg"),
+                    "clearance-offset": f"{offset}mm",
+                    "custom-clearance-svg": typst_str(
+                        f"/vehicles/{vehicle}/gen/offsets.svg"
+                    ),
+                    **git_args,
+                    "min-radius": "500mm",
+                    "top-padding": "2cm",
+                }
+                if paper == "a4":
+                    args["paper-size"] = typst_str("a4")
+                renders.append(
+                    Render(
+                        pdf=BUILD_DIR / "vehicles" / vehicle / f"{stem}_{suffix}.pdf",
+                        png=BUILD_DIR / "vehicles" / vehicle / f"{stem}_{suffix}.png",
+                        body=template_call(args),
+                    )
+                )
+    return renders
+
+
+def group_renders(group: str) -> list[Render]:
+    if group == "universal-letter":
+        return universal_renders("letter")
+    if group == "universal-a4":
+        return universal_renders("a4")
+    if group == "vehicle-letter":
+        return vehicle_renders("letter")
+    if group == "vehicle-a4":
+        return vehicle_renders("a4")
+    raise ValueError(f"unknown group: {group}")
+
+
+def group_stem(group: str) -> str:
+    return group.replace("-", "_")
+
+
+def write_typst(group: str, renders: list[Render]) -> Path:
+    MEGA_DIR.mkdir(parents=True, exist_ok=True)
+    typ_path = MEGA_DIR / f"{group_stem(group)}.typ"
+    parts = ['#import "/template.typ": template', ""]
+    for index, render in enumerate(renders):
+        parts.append(render.body)
+        if index != len(renders) - 1:
+            parts.append("#pagebreak()")
+        parts.append("")
+    typ_path.write_text("\n".join(parts))
+    return typ_path
+
+
+def run(cmd: list[str]) -> None:
+    print("+ " + " ".join(cmd), flush=True)
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+def split_pdf(mega_pdf: Path, renders: list[Render]) -> None:
+    reader = PdfReader(mega_pdf)
+    if len(reader.pages) != len(renders):
+        raise RuntimeError(
+            f"{mega_pdf} has {len(reader.pages)} pages, expected {len(renders)}"
+        )
+    for page, render in zip(reader.pages, renders, strict=True):
+        render.pdf.parent.mkdir(parents=True, exist_ok=True)
+        writer = PdfWriter()
+        writer.add_page(page)
+        with render.pdf.open("wb") as file:
+            writer.write(file)
+
+
+def move_png_pages(group: str, renders: list[Render]) -> None:
+    for index, render in enumerate(renders, start=1):
+        page_png = MEGA_DIR / f"{group_stem(group)}_page-{index}.png"
+        if not page_png.exists():
+            raise RuntimeError(f"missing Typst PNG page: {page_png}")
+        render.png.parent.mkdir(parents=True, exist_ok=True)
+        page_png.replace(render.png)
+
+
+def touch_outputs(stamp: Path | None, renders: list[Render]) -> None:
+    if stamp is not None:
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.touch()
+    for render in renders:
+        render.pdf.touch()
+        render.png.touch()
+
+
+def build_group(group: str, typst: str, ppi: int, stamp: Path | None) -> None:
+    renders = group_renders(group)
+    typ_path = write_typst(group, renders)
+    mega_pdf = MEGA_DIR / f"{group_stem(group)}.pdf"
+    png_pattern = MEGA_DIR / f"{group_stem(group)}_page-{{p}}.png"
+
+    for stale_png in MEGA_DIR.glob(f"{group_stem(group)}_page-*.png"):
+        stale_png.unlink()
+
+    run([typst, "compile", str(typ_path), str(mega_pdf), "--root", ".", "--font-path", "fonts"])
+    split_pdf(mega_pdf, renders)
+    run(
+        [
+            typst,
+            "compile",
+            str(typ_path),
+            str(png_pattern),
+            "--root",
+            ".",
+            "--font-path",
+            "fonts",
+            "--ppi",
+            str(ppi),
+        ]
+    )
+    move_png_pages(group, renders)
+    touch_outputs(stamp, renders)
+    print(f"built_group={group} pages={len(renders)}")
+
+
+def expected_outputs(groups: list[str]) -> list[Path]:
+    outputs: list[Path] = []
+    for group in groups:
+        for render in group_renders(group):
+            outputs.extend((render.pdf, render.png))
+    return outputs
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build grouped Typst template PDFs/PNGs.")
+    parser.add_argument(
+        "--group",
+        dest="groups",
+        action="append",
+        choices=("universal-letter", "universal-a4", "vehicle-letter", "vehicle-a4"),
+        required=True,
+        help="Mega render group to build. May be repeated.",
+    )
+    parser.add_argument("--typst", default="typst")
+    parser.add_argument("--ppi", type=int, default=144)
+    parser.add_argument("--stamp", type=Path)
+    parser.add_argument(
+        "--list-outputs",
+        action="store_true",
+        help="Print expected output paths for the selected groups without building.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.list_outputs:
+        for output in expected_outputs(args.groups):
+            print(output.relative_to(ROOT))
+        return 0
+
+    stamp = args.stamp
+    if stamp is not None and len(args.groups) != 1:
+        print("--stamp can only be used with one --group", file=sys.stderr)
+        return 2
+    for group in args.groups:
+        build_group(group, args.typst, args.ppi, stamp)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_build.py
+++ b/tools/verify_build.py
@@ -52,16 +52,20 @@ def verify_image(client, image_path):
 
 def main():
     # Standard setup from AGENTS.md
-    if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI") == "True":
-        print("Using Vertex AI...")
-        client = genai.Client(
-            vertexai=True,
-            project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
-            location="global"
-        )
-    else:
-        print("Using AI Studio...")
-        client = genai.Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+    os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
+    if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI") != "True":
+        raise SystemExit("GOOGLE_GENAI_USE_VERTEXAI must be True; API-key mode is not used.")
+
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("GOOGLE_CLOUD_PROJECT_ID")
+    if not project:
+        raise SystemExit("GOOGLE_CLOUD_PROJECT is required for Vertex AI verification.")
+
+    print("Using Vertex AI...")
+    client = genai.Client(
+        vertexai=True,
+        project=project,
+        location="global"
+    )
 
     files_to_check = []
     if len(sys.argv) > 1:

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ dependencies = [
     { name = "numpy" },
     { name = "opencv-python-headless" },
     { name = "pillow" },
+    { name = "pypdf" },
     { name = "scipy" },
     { name = "shapely" },
     { name = "trimesh" },
@@ -22,6 +23,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "opencv-python-headless", specifier = ">=4.11.0.86" },
     { name = "pillow", specifier = ">=12.1.0" },
+    { name = "pypdf", specifier = ">=6.11.0" },
     { name = "scipy", specifier = ">=1.17.0" },
     { name = "shapely", specifier = ">=2.1.2" },
     { name = "trimesh", specifier = ">=4.11.1" },
@@ -160,6 +162,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/26/c4188248bd5edaf543864fe4834aebe9c9cb4968b6f573ce014cc42d0720/pillow-12.1.0-cp314-cp314t-win32.whl", hash = "sha256:b17fbdbe01c196e7e159aacb889e091f28e61020a8abeac07b68079b6e626988", size = 6438703, upload-time = "2026-01-02T09:13:07.491Z" },
     { url = "https://files.pythonhosted.org/packages/b8/0e/69ed296de8ea05cb03ee139cee600f424ca166e632567b2d66727f08c7ed/pillow-12.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27b9baecb428899db6c0de572d6d305cfaf38ca1596b5c0542a5182e3e74e8c6", size = 7182927, upload-time = "2026-01-02T09:13:09.841Z" },
     { url = "https://files.pythonhosted.org/packages/fc/f5/68334c015eed9b5cff77814258717dec591ded209ab5b6fb70e2ae873d1d/pillow-12.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f61333d817698bdcdd0f9d7793e365ac3d2a21c1f1eb02b32ad6aefb8d8ea831", size = 2545104, upload-time = "2026-01-02T09:13:12.068Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/58/6dd97d78a4b17a7a6b9d1c6ad23895abc41f0fdc49c553cc05bdfdcc36d0/pypdf-6.11.0.tar.gz", hash = "sha256:062b51c81b0910e6d2755e99e1c5547a0a23b7d0a32322af66240d8edcfabe87", size = 6453975, upload-time = "2026-05-09T13:26:48.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/b1/68feb7eb3b99f0c020b414234825f4a5d70e0126c18d933770e8c93a35fc/pypdf-6.11.0-py3-none-any.whl", hash = "sha256:769394d5756d5b304c9b6bef88b54b1816b328e7e6fc9254e625529a15ed4ab8", size = 338819, upload-time = "2026-05-09T13:26:46.904Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add grouped mega Typst rendering for universal and vehicle template PDFs/PNGs
- preserve the old one-template compile path behind `INDIVIDUAL=1`
- add `make bench-build` to compare old vs new render performance
- force visual verification through Vertex AI instead of API-key mode

## Why
The build was launching Typst once per variant, which made clean render builds spend a lot of time on repeated startup/import/font work. Grouping pages into mega Typst documents keeps the public artifact filenames unchanged while reducing the number of Typst invocations.

## Validation
- `uvx ruff check . --select F841,F401 --fix`
- `make clean && make -j 16 universal-variants`
- `make bench-build`
  - `old_individual_seconds=20.652`
  - `new_mega_seconds=2.658`
  - `speedup=7.77x`
  - `outputs_checked=220`
- `make -j 16 render-templates`
- `make -j 16 all`
- visual contact sheet inspection of first/last PNGs from all four mega groups
- `uv run tools/verify_build.py build/c3_mount_45_75mm_letter.png`
